### PR TITLE
Remove usage of font

### DIFF
--- a/app.py
+++ b/app.py
@@ -59,7 +59,7 @@ async def changelogs(ctx):
 @bot.slash_command(guild_ids=guilds, description = "Makes the silly garflid image speak (image by @willy on wasteof)")
 async def garfild(ctx, text: str):
     
-    font = ImageFont.truetype("font.ttf", 30)
+    #font = ImageFont.truetype("font.ttf", 30)
     img = Image.open("pic.jpg")
     cx, cy = (325, 100)
     lines = textwrap.wrap(text, width=17)
@@ -69,7 +69,7 @@ async def garfild(ctx, text: str):
     for line in lines:
         w2,h2 = font.getsize(line)
         draw = ImageDraw.Draw(img)
-        draw.text(y_text , cx - (w/2), line, (0, 0, 0), font=ImageFont.truetype("font.ttf", 30))
+        draw.text((y_text, cx - w/2), line)
         img.save("edit.jpg")
         y_text += h2
 

--- a/app.py
+++ b/app.py
@@ -70,7 +70,7 @@ async def garfild(ctx, text: str):
     for line in lines:
         w2,h2 = font.getsize(line)
         draw = ImageDraw.Draw(img)
-        draw.text((cx - w/2, y_text), line, fill=(0,0,0))
+        draw.text((cx - 17*2, y_text), line, fill=(0,0,0))
         img.save("edit.jpg")
         y_text += h2
 

--- a/app.py
+++ b/app.py
@@ -60,6 +60,7 @@ async def changelogs(ctx):
 async def garfild(ctx, text: str):
     
     #font = ImageFont.truetype("font.ttf", 30)
+    font = ImageFont.load_default()
     img = Image.open("pic.jpg")
     cx, cy = (325, 100)
     lines = textwrap.wrap(text, width=17)
@@ -69,7 +70,7 @@ async def garfild(ctx, text: str):
     for line in lines:
         w2,h2 = font.getsize(line)
         draw = ImageDraw.Draw(img)
-        draw.text((y_text, cx - w/2), line)
+        draw.text((cx - w/2, y_text), line, fill=(0,0,0))
         img.save("edit.jpg")
         y_text += h2
 


### PR DESCRIPTION
Loading a nonexistent front caused the error. If you don't want to use a font, don't load it

I removed font parameters in the `draw.text()` function and fixed the xy parameter format (should be in tuple: `(x, y)`)

Now it doesn't throw an error and actually sends an image. You can set the position of text, etc